### PR TITLE
https://lab.civicrm.org/dev/core/-/issues/1215

### DIFF
--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -796,6 +796,11 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
         $paypalIPN = new CRM_Core_Payment_PayPalProIPN($params);
         break;
 
+      case 'PayPal_Express':
+        // "PayPal - Express"
+        $paypalIPN = new CRM_Core_Payment_PayPalProIPN($params);
+        break;       
+        
       case 'PayPal_Standard':
         // "PayPal - Website Payments Standard"
         $paypalIPN = new CRM_Core_Payment_PayPalIPN($params);


### PR DESCRIPTION
Repair support for PayPal Express by linking to PayPal Pro

Overview
----------------------------------------
PayPal is supporting different products for payment services, some of them are limited to certain markets / parts of the world.
PayPal Express is important for Europe, especially Germany, and in this market the only way to manage recurring contributions with PayPal.
Unfortunately, support for PayPal Express in CiviCRM core broke down some years ago. The issue is, that the payment notices ("IPN's") are not processed properly.

See: https://lab.civicrm.org/dev/core/-/issues/1215

Before
----------------------------------------
PayPal Express IPN's throw an exception, when trying to process to insert recurring contributions into CiviCRM

The contributions are processed within PayPal, but not entered into CiviCRM.


After
----------------------------------------
With the proposed commit, PayPal Express IPN's are processed the same way as PayPal Pro IPN's, thus making sure that future recurring contributions are processed correctly and entered automatically into CiviCRM.


Technical Details
----------------------------------------
n/a

Comments
----------------------------------------
n/a

